### PR TITLE
Adding CaDiCaL 1.3.0 to EESSI pilot 9.3.0

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -332,6 +332,12 @@ fail_msg="Installation of WRF failed, that's unexpected..."
 OMPI_MCA_pml=ucx UCX_TLS=tcp $EB WRF-3.9.1.1-foss-2020a-dmpar.eb -r --include-easyblocks-from-pr 2648
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+echo ">> Installing CaDiCaL 1.3.0..."
+ok_msg="CaDiCaL installed, let's solve some problems!"
+fail_msg="Installation of CaDiCaL failed, that's a pity..."
+$EB CaDiCaL-1.3.0-GCC-9.3.0.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 echo ">> Creating/updating Lmod cache..."
 export LMOD_RC="${EASYBUILD_INSTALLPATH}/.lmod/lmodrc.lua"
 if [ ! -f $LMOD_RC ]; then

--- a/eessi-2021.12.yml
+++ b/eessi-2021.12.yml
@@ -53,3 +53,7 @@ software:
          versions: 
            '3.9.1.1': 
              versionsuffix: -dmpar
+  CaDiCaL:
+     toolchains:
+       foss-2020a:
+         versions: ['1.3.0']

--- a/eessi-2021.12.yml
+++ b/eessi-2021.12.yml
@@ -55,5 +55,5 @@ software:
              versionsuffix: -dmpar
   CaDiCaL:
      toolchains:
-       foss-2020a:
+       GCC-9.3.0:
          versions: ['1.3.0']


### PR DESCRIPTION
Try a simpler package (no dependencies).

-----------------------

PRSO (Pull Request Status Overview)

|target|confirmed|built|validated|deployed|verified|comments|
|------|:----------:|:-----:|:---------:|:--------:|:--------:|--------|
|x86_64-generic| ✅ | ❔ | ❔ | ❔ | 👍 | _link(s) to details_ |
|x86_64-amd-zen2| ❌ | ❔ | ❔ | ❔ | 👍 | _link(s) to details_ |

(GHA could add a second comment used as _command log_: `confirm <target>`, `approve <target>`, `deploy <target>`, etc.)
