### PR TITLE
Adding CMake 3.16.4 to NESSI pilot 2021.12

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -221,13 +221,13 @@ fail_msg="Installation of ${GCC_EC} failed!"
 $EB ${GCC_EC} --robot --from-pr 14453 GCCcore-9.3.0.eb
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-## install CMake with custom easyblock that patches CMake when --sysroot is used
-#echo ">> Install CMake with fixed easyblock to take into account --sysroot"
-#ok_msg="CMake installed!"
-#fail_msg="Installation of CMake failed, what the ..."
-#$EB CMake-3.16.4-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2248
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
+# install CMake with custom easyblock that patches CMake when --sysroot is used
+echo ">> Install CMake with fixed easyblock to take into account --sysroot"
+ok_msg="CMake installed!"
+fail_msg="Installation of CMake failed, what the ..."
+$EB CMake-3.16.4-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2248
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 ## If we're building OpenBLAS for GENERIC, we need https://github.com/easybuilders/easybuild-easyblocks/pull/1946
 #echo ">> Installing OpenBLAS..."
 #ok_msg="Done with OpenBLAS!"


### PR DESCRIPTION
Destination for this PR should be the branch nessi-2021.12 which is used to build the software stack version 2021.12 for the NESSI pilot.