### PR TITLE
nessi.no/2022.11 - adding CMake, OpenBLAS, OpenMPI, Python, Perl with GCC/9.3.0

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -220,46 +220,48 @@ fail_msg="Installation of ${GCC_EC} failed!"
 $EB ${GCC_EC} --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
-## install CMake with custom easyblock that patches CMake when --sysroot is used
-#echo ">> Install CMake with fixed easyblock to take into account --sysroot"
-#ok_msg="CMake installed!"
-#fail_msg="Installation of CMake failed, what the ..."
-#$EB CMake-3.16.4-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2248
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
-## If we're building OpenBLAS for GENERIC, we need https://github.com/easybuilders/easybuild-easyblocks/pull/1946
-#echo ">> Installing OpenBLAS..."
-#ok_msg="Done with OpenBLAS!"
-#fail_msg="Installation of OpenBLAS failed!"
-#if [[ $GENERIC -eq 1 ]]; then
-#    echo_yellow ">> Using https://github.com/easybuilders/easybuild-easyblocks/pull/1946 to build generic OpenBLAS."
-#    $EB --include-easyblocks-from-pr 1946 OpenBLAS-0.3.9-GCC-9.3.0.eb --robot
-#else
-#    $EB OpenBLAS-0.3.9-GCC-9.3.0.eb --robot
-#fi
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
-#echo ">> Installing OpenMPI..."
-#ok_msg="OpenMPI installed, w00!"
-#fail_msg="Installation of OpenMPI failed, that's not good..."
-#$EB OpenMPI-4.0.3-GCC-9.3.0.eb --robot
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
-## install Python
-#echo ">> Install Python 2.7.18 and Python 3.8.2..."
-#ok_msg="Python 2.7.18 and 3.8.2 installed, yaay!"
-#fail_msg="Installation of Python failed, oh no..."
-#$EB Python-2.7.18-GCCcore-9.3.0.eb Python-3.8.2-GCCcore-9.3.0.eb --robot
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
-#echo ">> Installing Perl..."
-#ok_msg="Perl installed, making progress..."
-#fail_msg="Installation of Perl failed, this never happens..."
-## use enhanced Perl easyblock from https://github.com/easybuilders/easybuild-easyblocks/pull/2640
-## to avoid trouble when using long installation prefix (for example with EESSI pilot 2021.12 on skylake_avx512...)
+# install CMake with custom easyblock that patches CMake when --sysroot is used
+echo ">> Install CMake with fixed easyblock to take into account --sysroot"
+ok_msg="CMake installed!"
+fail_msg="Installation of CMake failed, what the ..."
+$EB CMake-3.16.4-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2248
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+# If we're building OpenBLAS for GENERIC, we need https://github.com/easybuilders/easybuild-easyblocks/pull/1946
+echo ">> Installing OpenBLAS..."
+ok_msg="Done with OpenBLAS!"
+fail_msg="Installation of OpenBLAS failed!"
+if [[ $GENERIC -eq 1 ]]; then
+    echo_yellow ">> Using https://github.com/easybuilders/easybuild-easyblocks/pull/1946 to build generic OpenBLAS."
+    $EB --include-easyblocks-from-pr 1946 OpenBLAS-0.3.9-GCC-9.3.0.eb --robot
+else
+    $EB OpenBLAS-0.3.9-GCC-9.3.0.eb --robot
+fi
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+echo ">> Installing OpenMPI..."
+ok_msg="OpenMPI installed, w00!"
+fail_msg="Installation of OpenMPI failed, that's not good..."
+$EB OpenMPI-4.0.3-GCC-9.3.0.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+# install Python
+echo ">> Install Python 2.7.18 and Python 3.8.2..."
+ok_msg="Python 2.7.18 and 3.8.2 installed, yaay!"
+fail_msg="Installation of Python failed, oh no..."
+$EB Python-2.7.18-GCCcore-9.3.0.eb Python-3.8.2-GCCcore-9.3.0.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
+echo ">> Installing Perl..."
+ok_msg="Perl installed, making progress..."
+fail_msg="Installation of Perl failed, this never happens..."
+# use enhanced Perl easyblock from https://github.com/easybuilders/easybuild-easyblocks/pull/2640
+# to avoid trouble when using long installation prefix (for example with EESSI pilot 2021.12 on skylake_avx512...)
+# included since EB v4.5.2 see https://docs.easybuild.io/en/latest/Release_notes.html#easybuild-v4-5-2-january-24th-2022
 #$EB Perl-5.30.2-GCCcore-9.3.0.eb --robot --include-easyblocks-from-pr 2640
-#check_exit_code $? "${ok_msg}" "${fail_msg}"
-#
+$EB Perl-5.30.2-GCCcore-9.3.0.eb --robot
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 #echo ">> Installing Qt5..."
 #ok_msg="Qt5 installed, phieuw, that was a big one!"
 #fail_msg="Installation of Qt5 failed, that's frustrating..."


### PR DESCRIPTION
- CMake-3.16.4-GCCcore-9.3.0.eb  --include-easyblocks-from-pr 2248
- OpenBLAS-0.3.9-GCC-9.3.0.eb (`generic`:  --include-easyblocks-from-pr 1946)
- OpenMPI-4.0.3-GCC-9.3.0.eb
- Python-2.7.18-GCCcore-9.3.0.eb
- Python-3.8.2-GCCcore-9.3.0.eb
- Perl-5.30.2-GCCcore-9.3.0.eb