### PR TITLE
nessi.no/2022.11 - adding OpenSSL-1.1

### DIFF
--- a/EESSI-pilot-install-software.sh
+++ b/EESSI-pilot-install-software.sh
@@ -220,6 +220,21 @@ fail_msg="Installation of ${GCC_EC} failed!"
 $EB ${GCC_EC} --robot
 check_exit_code $? "${ok_msg}" "${fail_msg}"
 
+# install OpenSSL-1.1 (dependcy for some of the following built with GCC/10.3.0)
+echo ">> Installing OpenSSL-1.1 .. skipping sanity check on proxied nodes"
+ok_msg="Yeah, got OpenSSL-1.1 installed"
+fail_msg="Oh no, installing OpenSSL-1.1 failed"
+if [[ "x${http_proxy}" == "x" ]]; then
+  echo "no proxy configured, assume build node has direct access to internet; not skipping sanity checks"
+  $EB OpenSSL-1.1.eb --robot
+else
+  echo "proxy configured '${http_proxy}', assume build node has NO direct access to internet; skipping sanity checks"
+  $EB --copy-ec OpenSSL-1.1.eb
+  patch OpenSSL-1.1.eb < patches/easyconfigs/o/OpenSSL-1.1.eb.sanity-check-patch
+  $EB OpenSSL-1.1.eb --robot
+fi
+check_exit_code $? "${ok_msg}" "${fail_msg}"
+
 # install CMake with custom easyblock that patches CMake when --sysroot is used
 echo ">> Install CMake with fixed easyblock to take into account --sysroot"
 ok_msg="CMake installed!"

--- a/patches/easyconfigs/o/OpenSSL-1.1.eb.sanity-check-patch
+++ b/patches/easyconfigs/o/OpenSSL-1.1.eb.sanity-check-patch
@@ -1,0 +1,9 @@
+--- OpenSSL-1.1.eb.original	2022-11-12 12:46:35.000000000 +0100
++++ OpenSSL-1.1.eb	2022-11-21 09:46:45.000000000 +0100
+@@ -36,4 +36,6 @@
+     }),
+ ]
+ 
++skipsteps = ['sanitycheck']
++
+ moduleclass = 'system'


### PR DESCRIPTION
Skipping sanity check for build nodes without direct access to the internet. One of the sanity checks implemented by the easyblock `EB_OpenSSL_wrapper` is to run someting like

`openssl s_client github.com:443 ...`

which does not pick up proxy settings via environment variables (`http_proxy`, `https_proxy`).

Another way could be to "patch" the easyblock such that it uses the proxy (openssl option `-proxy`).