### PR TITLE
show job cfg value of 'accelerator' (test bot PR292)

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -123,6 +123,9 @@ EESSI_SOFTWARE_SUBDIR_OVERRIDE=${EESSI_SOFTWARE_SUBDIR_OVERRIDE:-${CPU_TARGET}}
 export EESSI_SOFTWARE_SUBDIR_OVERRIDE
 echo "bot/build.sh: EESSI_SOFTWARE_SUBDIR_OVERRIDE='${EESSI_SOFTWARE_SUBDIR_OVERRIDE}'"
 
+ACCELERATOR==$(cfg_get_value "architecture" "accelerator")
+echo ${ACCELERATOR}
+
 # get EESSI_OS_TYPE from .architecture.os_type in ${JOB_CFG_FILE} (default: linux)
 EESSI_OS_TYPE=$(cfg_get_value "architecture" "os_type")
 export EESSI_OS_TYPE=${EESSI_OS_TYPE:-linux}


### PR DESCRIPTION
Just for testing https://github.com/EESSI/eessi-bot-software-layer/pull/292

We should see the dev bot at eX3 responding when the PR is opened, and then we just close it and because there was no job there should be no comment about moving the job directories to the 🗑️ 